### PR TITLE
Add UTF-8 encoding for silent PEP-263

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/lenny/__init__.py
+++ b/lenny/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
 """
 Copyright (c) 2017 davidsluo
 


### PR DESCRIPTION
Added .gitignore and silent PEP-263 Warning
```
SyntaxError: Non-ASCII character '\xe1' in file lenny/__init__.py on line 27, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```